### PR TITLE
Refactored to remove JoinModule dependency

### DIFF
--- a/functions/Get-WMIMonitorInfo.ps1
+++ b/functions/Get-WMIMonitorInfo.ps1
@@ -1,28 +1,28 @@
 <#
 .SYNOPSIS
-    Short description
+	Short description
 
 .DESCRIPTION
-    Long description
+	Long description
 
 .PARAMETER ParameterName
-    Description of parameter input
+	Description of parameter input
 
 .EXAMPLE
-    PS>
+	PS>
 
-    Example of how to use this cmdlet
+	Example of how to use this cmdlet
 
 .EXAMPLE
-    PS>
+	PS>
 
-    Another example of how to use this cmdlet
+	Another example of how to use this cmdlet
 
 .LINK
-    Any related function or website
+	Any related function or website
 
 .NOTES
-    General notes
+	General notes
 #>
 
 
@@ -40,70 +40,69 @@
 .EXTERNALMODULEDEPENDENCIES
 
 .RELEASENOTES
-    1.0.0 - Initial Release
+	1.0.0 - Initial Release
 #>
 
 [CmdletBinding()]
 
 param(
-    [Parameter()]
-    [PSObject] $ParameterName
+	[Parameter()]
+	[PSObject] $ParameterName
 )
 
 function Get-WMIMonitorInfo {
-    [CmdletBinding()]
-    param(
-        [string]$ComputerName
-    )
-
-    if(-not (Get-Module JoinModule)){
-        Write-Verbose "JoinModule was not detected!"
-        if($PSVersionTable.PSEdition -eq "Core") {
-            Write-Verbose "PowerShell Core detected, Installing JoinModule..."
-            Install-Module JoinModule
-        }else{
-            if(([Security.Principal.WindowsPrincipal] `
-            [Security.Principal.WindowsIdentity]::GetCurrent() `
-            ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
-                Write-Verbose "Admin check succeeded, Installing JoinModule..."
-                Install-Module JoinModule    
-            }else{
-                Write-Error "Need to be admin to install dependency JoinModule! Aborting operation."
-            }
-        }
-    }
-
-    # Initialize the output arraylist
-    $output = New-Object System.Collections.ArrayList
-
-    if($ComputerName){
-        if(Test-Connection -ComputerName $ComputerName -Count 1 -Quiet) {
-            Write-Verbose "Successfully pinged $ComputerName"
-        }else{
-            Write-Error "Could not ping remote computer $ComputerName."
-        }
-        $WMIMonitorID =                 Get-CimInstance -Namespace root\wmi -ClassName WMIMonitorID -ComputerName $ComputerName -ErrorAction SilentlyContinue
-        $WmiMonitorBasicDisplayParams = Get-Ciminstance -Namespace root\wmi -ClassName WmiMonitorBasicDisplayParams -ComputerName $ComputerName -ErrorAction SilentlyContinue
-        $WmiMonitorConnectionParams   = Get-CimInstance -Namespace root\wmi -ClassName WmiMonitorConnectionParams -ComputerName $ComputerName -ErrorAction SilentlyContinue
-    }else{
-        $WMIMonitorID =                 Get-CimInstance -ClassName WMIMonitorID -Namespace root\wmi -ErrorAction SilentlyContinue
-        $WmiMonitorBasicDisplayParams = Get-Ciminstance -Namespace root\wmi -ClassName WmiMonitorBasicDisplayParams -ErrorAction SilentlyContinue
-        $WmiMonitorConnectionParams   = Get-CimInstance -Namespace root\wmi -ClassName WmiMonitorConnectionParams -ErrorAction SilentlyContinue
-    }
-
-    # Join the two WMI Classes so they can be parsed together
-    if($WMIMonitorID -and $WmiMonitorBasicDisplayParams -and $WmiMonitorConnectionParams){
-        $Combined = $WMIMonitorID | 
-            Join-Object $WmiMonitorBasicDisplayParams -On InstanceName,PSComputerName |
-            Join-Object $WmiMonitorConnectionParams -On InstanceName,PSComputerName
-    }else{
-        Write-Error "No result returned for Monitor Info for $ComputerName. Does your target computer actually have monitors?"
-    }
-
-    foreach($Monitor in $Combined) {
-        Write-Verbose $Monitor
-        $Member = Build-ArrayObject -Monitor $Monitor
-        $output.Add($Member) | Out-Null
-    }
-    $output
+	[CmdletBinding()]
+	param(
+		[string]$ComputerName
+	)
+	
+	# Initialize the output arraylist
+	$output = New-Object System.Collections.ArrayList
+	
+	$cimParams = @{
+		"ErrorAction" = "Stop"
+		"Namespace" = "root\wmi"
+	}
+	
+	if($ComputerName) {
+		
+		# Bail if the computer can't be pinged
+		if(Test-Connection -ComputerName $ComputerName -Count 1 -Quiet) {
+			Write-Verbose "Successfully pinged $ComputerName"
+		}
+		else {
+			Throw "Could not ping remote computer $ComputerName."
+		}
+		
+		$cimParams.ComputerName = $ComputerName
+	}
+	
+	# Get all monitor info for all monitors
+	try {
+		$id = Get-CimInstance -ClassName WMIMonitorID @cimParams
+		$displayParams = Get-Ciminstance -ClassName WmiMonitorBasicDisplayParams @cimParams
+		$connectionParams = Get-CimInstance -ClassName WmiMonitorConnectionParams @cimParams
+	}
+	catch {
+		Throw "Error gathering monitor info from computer `"$ComputerName`"!"
+	}
+	
+	# Loop through each monitor's ID info object
+	$monitors = $id | ForEach-Object {
+		$monitor = $_
+		
+		# Add this monitor's display param info object as a child object
+		$monitorDisplayParams = $displayParams | Where { $_.InstanceName -eq $monitor.InstanceName }
+		$monitor | Add-Member -NotePropertyName "DisplayParams" -NotePropertyValue $monitorDisplayParams
+		
+		# Add this monitor's connection param info object as a child object
+		$monitorConnectionParams = $connectionParams | Where { $_.InstanceName -eq $monitor.InstanceName }
+		$monitor | Add-Member -NotePropertyName "ConnectionParams" -NotePropertyValue $monitorConnectionParams
+		
+		$monitor
+	}
+	
+	$monitors | ForEach-Object {
+		Build-ArrayObject -Monitor $_
+	}
 }

--- a/internal/functions/Build-ArrayObject.ps1
+++ b/internal/functions/Build-ArrayObject.ps1
@@ -20,5 +20,6 @@ function Build-ArrayObject {
 		Size					= Measure-Diagonal $Monitor.DisplayParams.MaxHorizontalImageSize $Monitor.DisplayParams.MaxVerticalImageSize
 		Ratio					= Measure-Ratio $Monitor.DisplayParams.MaxHorizontalImageSize $Monitor.DisplayParams.MaxVerticalImageSize
 		VideoOutputTechnology	= Get-VideoOutputTechnology $Monitor.ConnectionParams.VideoOutputTechnology
+		RawMonitorInfo			= $Monitor
 	}
 }

--- a/internal/functions/Build-ArrayObject.ps1
+++ b/internal/functions/Build-ArrayObject.ps1
@@ -4,15 +4,21 @@ function Build-ArrayObject {
 	)
 	
 	[PSCustomObject]@{
-		PSComputerName =		($Monitor.PSComputerName).Trim()
-		Manufacturer =			(Get-Manufacturer $Monitor.ManufacturerName).Trim()
-		ProductCode =			(Decode $Monitor.ProductCodeID).Trim()
-		Serial =				(Decode $Monitor.SerialNumberID).Trim()
-		Name =					(Decode $Monitor.UserFriendlyName).Trim()
-		WeekOfManufacture =		("$($Monitor.WeekOfManufacture)").Trim()
-		YearOfManufacture =		("$($Monitor.YearOfManufacture)").Trim()
-		Size =					(Measure-Diagonal $Monitor.DisplayParams.MaxHorizontalImageSize $Monitor.DisplayParams.MaxVerticalImageSize).Trim()
-		Ratio =					(Measure-Ratio $Monitor.DisplayParams.MaxHorizontalImageSize $Monitor.DisplayParams.MaxVerticalImageSize).Trim()
-		VideoOutputTechnology =	(Get-VideoOutputTechnology $Monitor.ConnectionParams.VideoOutputTechnology).Trim()
+		PSComputerName			= $Monitor.PSComputerName
+		Manufacturer			= Get-Manufacturer $Monitor.ManufacturerName
+		#ProductCodeRaw			= $Monitor.ProductCodeID
+		#ProductCodeRawFull		= "$($Monitor.ProductCodeID -join ",")"
+		ProductCode				= Decode $Monitor.ProductCodeID
+		#SerialRaw				= $Monitor.SerialNumberID
+		#SerialRawFull			= "$($Monitor.SerialNumberID -join ",")"
+		Serial					= Decode $Monitor.SerialNumberID
+		#NameRaw				= $Monitor.UserFriendlyName
+		#NameRawFull			= "$($Monitor.UserFriendlyName -join ",")"
+		Name					= Decode $Monitor.UserFriendlyName
+		WeekOfManufacture		= "$($Monitor.WeekOfManufacture)"
+		YearOfManufacture		= "$($Monitor.YearOfManufacture)"
+		Size					= Measure-Diagonal $Monitor.DisplayParams.MaxHorizontalImageSize $Monitor.DisplayParams.MaxVerticalImageSize
+		Ratio					= Measure-Ratio $Monitor.DisplayParams.MaxHorizontalImageSize $Monitor.DisplayParams.MaxVerticalImageSize
+		VideoOutputTechnology	= Get-VideoOutputTechnology $Monitor.ConnectionParams.VideoOutputTechnology
 	}
 }

--- a/internal/functions/Build-ArrayObject.ps1
+++ b/internal/functions/Build-ArrayObject.ps1
@@ -1,21 +1,18 @@
 function Build-ArrayObject {
-    param(
-        $Monitor
-    )
-    $output = New-Object System.Collections.ArrayList
-    
-    $output = [PSCustomObject]@{
-        Manufacturer =              Get-Manufacturer -Monitor $Monitor
-        ProductCode =               Decode $Monitor.ProductCodeID
-        Serial =                    Decode $Monitor.SerialNumberID
-        Name =                      Decode $Monitor.UserFriendlyName
-        WeekOfManufacture =         $Monitor.WeekOfManufacture
-        YearOfManufacture =         $Monitor.YearOfManufacture
-        Size =                      Measure-Diagonal -Monitor $Monitor
-        Ratio =                     Measure-Ratio -Monitor $Monitor
-        VideoOutputTechnology =     Get-VideoOutputTechnology -Monitor $Monitor
-        PSComputerName =            $Monitor.PSComputerName
-    }
-    Write-Verbose $output
-    $output
+	param(
+		$Monitor
+	)
+	
+	[PSCustomObject]@{
+		PSComputerName =		($Monitor.PSComputerName).Trim()
+		Manufacturer =			(Get-Manufacturer $Monitor.ManufacturerName).Trim()
+		ProductCode =			(Decode $Monitor.ProductCodeID).Trim()
+		Serial =				(Decode $Monitor.SerialNumberID).Trim()
+		Name =					(Decode $Monitor.UserFriendlyName).Trim()
+		WeekOfManufacture =		("$($Monitor.WeekOfManufacture)").Trim()
+		YearOfManufacture =		("$($Monitor.YearOfManufacture)").Trim()
+		Size =					(Measure-Diagonal $Monitor.DisplayParams.MaxHorizontalImageSize $Monitor.DisplayParams.MaxVerticalImageSize).Trim()
+		Ratio =					(Measure-Ratio $Monitor.DisplayParams.MaxHorizontalImageSize $Monitor.DisplayParams.MaxVerticalImageSize).Trim()
+		VideoOutputTechnology =	(Get-VideoOutputTechnology $Monitor.ConnectionParams.VideoOutputTechnology).Trim()
+	}
 }

--- a/internal/functions/Decode.ps1
+++ b/internal/functions/Decode.ps1
@@ -1,9 +1,11 @@
 function Decode {
-    # Source: https://support.moonpoint.com/os/windows/PowerShell/monitor_mfg.php
-    If ($args[0] -is [System.Array]) {
-        [System.Text.Encoding]::ASCII.GetString($args[0])
-    }
-    Else {
-        "Not Found"
-    }
+	# Source: https://support.moonpoint.com/os/windows/PowerShell/monitor_mfg.php
+	if($args[0] -is [System.Array]) {
+		$decoded = [System.Text.Encoding]::ASCII.GetString($args[0])
+	}
+	else {
+		$decoded = "Undecodable"
+	}
+	
+	"$decoded"
 }

--- a/internal/functions/Decode.ps1
+++ b/internal/functions/Decode.ps1
@@ -1,11 +1,20 @@
 function Decode {
-	# Source: https://support.moonpoint.com/os/windows/PowerShell/monitor_mfg.php
-	if($args[0] -is [System.Array]) {
-		$decoded = [System.Text.Encoding]::ASCII.GetString($args[0])
-	}
-	else {
-		$decoded = "Undecodable"
+	param(
+		$Value
+	)
+	
+	if(-not($Value -is [System.Array])) {
+		return "Undecodable"
 	}
 	
-	"$decoded"
+	# https://learn.microsoft.com/en-us/answers/questions/1525390/command-to-get-monitor-model-number-and-serial-num
+	# Filters out padding from EDID codes
+	$valueUnpadded = $Value | Where-Object { $_ -ne 0 } | ForEach-Object { [char]$_ }
+	
+	$valueString = $valueUnpadded -join ""
+	
+	# Source: https://support.moonpoint.com/os/windows/PowerShell/monitor_mfg.php
+	#$decoded = [System.Text.Encoding]::Unicode.GetString($args[0])
+	
+	$valueString
 }

--- a/internal/functions/Get-Manufacturer.ps1
+++ b/internal/functions/Get-Manufacturer.ps1
@@ -1,21 +1,18 @@
 function Get-Manufacturer {
-    param (
-        $Monitor
-    )
-    $output = Decode $Monitor.ManufacturerName
-    Write-Verbose "Raw decoded output for ManufacturerName is $output"
-    switch ($output) {
-        DEL {$output = "Dell"}
-        HPN {$output = "HP"}
-        HWP {$output = "HP"}
-        ACI {$output = "ASUS"}
-        WAC {$output = "Wacom"}
-        TSB {$output = "Toshiba"}
-        VSC {$output = "ViewSonic"}
-        BBY {$output = "Best Buy"}
-        CEI {$output = "Crestron"}
-        ATL {$output = "Atlona"}
-        PNR {$output = "Planar"}
-    }
-    $output
+	param (
+		$ManufacturerName
+	)
+	switch(Decode $ManufacturerName) {
+		"DEL" { "Dell" }
+		"HPN" { "HP" }
+		"HWP" { "HP" }
+		"ACI" { "ASUS" }
+		"WAC" { "Wacom" }
+		"TSB" { "Toshiba" }
+		"VSC" { "ViewSonic" }
+		"BBY" { "Best Buy" }
+		"CEI" { "Crestron" }
+		"ATL" { "Atlona" }
+		"PNR" { "Planar" }
+	}
 }

--- a/internal/functions/Get-VideoOutputTechnology.ps1
+++ b/internal/functions/Get-VideoOutputTechnology.ps1
@@ -1,32 +1,29 @@
 function Get-VideoOutputTechnology {
-    param(
-        $Monitor
-    )
+	param(
+		$VideoOutputTechnology
+	)
 
-    $output = $Monitor.VideoOutputTechnology
-
-    switch($output) {
-        -2          {"Unassigned"}
-        -1          {"Unknown"}
-        0           {"VGA"}
-        1           {"S-vidio"}
-        2           {"Composite Video"}
-        3           {"Component Video"}
-        4           {"DVI"}
-        5           {"HDMI"}
-        6           {"LVDS"}
-        8           {"D-Jpn"}
-        9           {"SDI"}
-        10          {"External DisplayPort"}
-        11          {"Embedded DisplayPort"}
-        12          {"External UDI"}
-        13          {"Embedded UDI"}
-        14          {"SDTV"}
-        15          {"Miracast"}
-        16          {"Wired Indirect Display"}
-        2147483648  {"Internal Laptop Display"}
-        4294967295  {"Remote Desktop"}
-        Default     {$output}
-    }
-    
+	switch($VideoOutputTechnology) {
+		-2			{"Unassigned"}
+		-1			{"Unknown"}
+		0			{"VGA"}
+		1			{"S-vidio"}
+		2			{"Composite Video"}
+		3			{"Component Video"}
+		4			{"DVI"}
+		5			{"HDMI"}
+		6			{"LVDS"}
+		8			{"D-Jpn"}
+		9			{"SDI"}
+		10			{"External DisplayPort"}
+		11			{"Embedded DisplayPort"}
+		12			{"External UDI"}
+		13			{"Embedded UDI"}
+		14			{"SDTV"}
+		15			{"Miracast"}
+		16			{"Wired Indirect Display"}
+		2147483648	{"Internal Laptop Display"}
+		4294967295	{"Remote Desktop"}
+		Default	 {$VideoOutputTechnology}
+	}
 }

--- a/internal/functions/Measure-Diagonal.ps1
+++ b/internal/functions/Measure-Diagonal.ps1
@@ -1,16 +1,18 @@
 function Measure-Diagonal {
-    param (
-        $Monitor
-    )
-
-    $Horizontal =   $Monitor | Select-Object -ExpandProperty MaxHorizontalImageSize
-    $Vertical =     $Monitor | Select-Object -ExpandProperty MaxVerticalImageSize
-
-    # Convert to Inches from CM
-    $Horizontal =   [System.Math]::Round(($Horizontal/2.54),2)
-    $Vertical =     [System.Math]::Round(($Vertical/2.54),2)
-
-    # Pythagorean Theorem rounded to the nearest inch
-    $Diagonal = [System.Math]::Round([System.Math]::Sqrt([System.Math]::Pow($Horizontal,2) + [System.Math]::Pow($Vertical,2)),0)
-    $Diagonal
+	param (
+		$Horizontal,
+		$Vertical
+	)
+	Write-Verbose "Horizontal in.: $Horizontal, Vertical in.: $Vertical"
+	
+	# Convert to Inches from CM
+	$Horizontal	= [System.Math]::Round(($Horizontal/2.54),2)
+	$Vertical	= [System.Math]::Round(($Vertical/2.54),2)
+	Write-Verbose "Horizontal cm.: $Horizontal, Vertical cm.: $Vertical"
+	
+	# Pythagorean Theorem rounded to the nearest inch
+	$Diagonal = [System.Math]::Round([System.Math]::Sqrt([System.Math]::Pow($Horizontal,2) + [System.Math]::Pow($Vertical,2)),0)
+	Write-Verbose "Diagonal: $Diagonal"
+	
+	"$Diagonal"
 }

--- a/internal/functions/Measure-Ratio.ps1
+++ b/internal/functions/Measure-Ratio.ps1
@@ -1,28 +1,24 @@
 function Measure-Ratio {
-    param(
-        $Monitor
-    )
-
-    $Horizontal =   $Monitor | Select-Object -ExpandProperty MaxHorizontalImageSize
-    $Vertical =     $Monitor | Select-Object -ExpandProperty MaxVerticalImageSize
-
-    # Convert to Inches from CM
-    $Horizontal =   [System.Math]::Round(($Horizontal/2.54),2)
-    $Vertical =     [System.Math]::Round(($Vertical/2.54),2)
-
-    $Ratio = [System.Math]::Round(($Horizontal/$Vertical),2)
-    switch($Ratio){
-        {$_ -ge 1.70 -and $_ -le 1.85} {$Numerator = 16; $Denominator = 9}
-        {$_ -ge 1.57 -and $_ -le 1.63} {$Numerator = 16; $Denominator = 10}
-        {$_ -ge 1.20 -and $_ -le 1.40} {$Numerator = 4; $Denominator = 3}
-    }
-
-    if($Numerator -and $Denominator){
-        $output = "$($Numerator):$($Denominator)"
-    }
-    if($output){
-        $output
-    }else{
-        $Ratio
-    }
+	param(
+		$Horizontal,
+		$Vertical
+	)
+	
+	# Convert to Inches from CM
+	$Horizontal	= [System.Math]::Round(($Horizontal/2.54),2)
+	$Vertical	= [System.Math]::Round(($Vertical/2.54),2)
+	
+	$Ratio = [System.Math]::Round(($Horizontal/$Vertical),2)
+	switch($Ratio) {
+		{$_ -ge 1.70 -and $_ -le 1.85} {$Numerator = 16; $Denominator = 9}
+		{$_ -ge 1.57 -and $_ -le 1.63} {$Numerator = 16; $Denominator = 10}
+		{$_ -ge 1.20 -and $_ -le 1.40} {$Numerator = 4; $Denominator = 3}
+	}
+	
+	if($Numerator -and $Denominator) {
+		"$($Numerator):$($Denominator)"
+	}
+	else {
+		"$Ratio"
+	}
 }


### PR DESCRIPTION
Refactored to remove JoinModule dependency. Also simplified a few things.

Side note: For some reason, when using Format-Table on this module's output (both before and after these changes), the resulting table has misaligned headers. At first I thought it might have something to do with weird characters being included in the returned values, so I also tried several things to mitigate that; namely making sure all returned data was trimmed and returned as strings. However nothing I did seemed to work. Using Out-GridView instead of Format-Table shows that the output is still a valid PowerShell object, so I suspect this is just some rendering bug within PowerShell or Windows Terminal. But I haven't been able to replicate the behavior in any other custom modules such as Get-MachineInfo, or any vanilla modules such as Get-Service, etc. Googling the issue hasn't been fruitful, because the results are just filled with people talking about unrelated alignment issues. So I have no idea why this happens or how to fix it.